### PR TITLE
Crash application on Mongo read errors

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -179,7 +179,7 @@ func (t *Tailer) Read() {
 			case <-t.stop:
 				return
 			case err := <-errs:
-				log.Errorf("Failure in errors from gtm: %s", err)
+				log.Fatalf("Exiting: Mongo tailer returned error %s", err.Error())
 			case op := <-ops:
 				t.counters.read.Incr(1)
 				log.WithFields(log.Fields{


### PR DESCRIPTION
Mongo read/connectivity issues are causing this application to stop
working silently. Instead of silently receiving them and logging, we
will crash the application and rely on external process monitor to
revive the service.

In future we can consider more graceful recovery mechanism with exiting
`Read()` loop and restarting it when connectivity issues arise.