### PR TITLE
Add session Refresh for Mongo connection issues

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -181,6 +181,7 @@ func (t *Tailer) Read() {
 				return
 			case err := <-errs:
 				if matched, _ := regexp.MatchString("i/o timeout", err.Error()); matched {
+					log.Errorf("Problem connecting to mongo: %s", err.Error())
 					t.session.Refresh()
 				} else {
 					log.Fatalf("Exiting: Mongo tailer returned error %s", err.Error())


### PR DESCRIPTION
According to this PR information, the preferred mechanism for dealing
with timeout on a session is to `.Refresh()` and retry.

https://github.com/go-mgo/mgo/issues/216