### PR TITLE
Fix DELETE actions being broken due to missing _id

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -409,10 +409,8 @@ func (t *Tailer) processOp(op *gtm.Op, workerType string) {
 		logFn(s, err)
 	case op.IsDelete() && t.env.allowDeletes:
 		t.counters.delete.Incr(1)
-		// Deletes have empty op.Data
-		// We patch in the op.Id instead for consistent data
-		// Bad idea? Should we always rely on op.ID? instead?
-		s, err := t.pg.NamedExec(o.BuildDelete(), data)
+		deleteSQL := o.BuildDelete()
+		s, err := t.pg.NamedExec(deleteSQL, data)
 		logFn(s, err)
 	}
 }

--- a/utils.go
+++ b/utils.go
@@ -129,10 +129,6 @@ func SanitizeData(pgFields Fields, op *gtm.Op) map[string]interface{} {
 	if err != nil {
 		log.Errorf("Failed to marshal op.Data into json %s", err.Error())
 	}
-	// Normalize data map to always include the Id with conversion
-	if op.Id != nil {
-		output["_id"] = op.Id
-	}
 
 	for k, v := range pgFields {
 		// Dot notation extraction
@@ -156,6 +152,15 @@ func SanitizeData(pgFields Fields, op *gtm.Op) map[string]interface{} {
 			}
 		}
 	}
+
+	// Normalize data map to always include the Id with conversion
+	// Required for delete actions that have a missing _id field in
+	// op.Data. Must occur after the preceeding iterative block
+	// in order to avoid being overwritten with nil.
+	if op.Id != nil {
+		output["_id"] = op.Id
+	}
+
 	return output
 }
 


### PR DESCRIPTION
Fixes bug where DELETES were silently failing.
Deletes were silently failing due to empty op.Data["_id"] fields.
Mongo's oplog schema is inconsistent as a source of this, so we need to
patch it in at the end of the sanitize action.

Tested against a staging system to verify that they now propagate.